### PR TITLE
Fix incorrect treatment of backticks with only one character enclosed

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -69,7 +69,7 @@ syntax match  mkdListItem  /^\s*\d\+\.\s\+.*\n\(\(^.\+\n\)*\n\?\)\(\(^\(\s\{4}\|
 syntax match  mkdBlockCode  /^\s*\n\(^\(\s\{4}\|\t\).*\n\)\+/
 syntax match  mkdListCode   /^\s*\n\(^\(\s\{8}\|\t{2}\).*\n\)\+/
 syntax match  mkdLineBreak /  \+$/
-syntax region mkdCode       start=/\\\@<!`[^`]/     end=/\\\@<![^`]`/
+syntax region mkdCode       start=/\\\@<!`[^`]\@=/     end=/\\\@<![^`]`/
 syntax region mkdCode       start=/\s*``[^`]*/  end=/[^`]*``\s*/
 syntax region mkdBlockquote start=/^\s*>/       end=/$/           contains=mkdLineBreak,mkdLineContinue,@Spell
 syntax region mkdCode       start="<pre[^>]*>"  end="</pre>"

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -69,7 +69,7 @@ syntax match  mkdListItem  /^\s*\d\+\.\s\+.*\n\(\(^.\+\n\)*\n\?\)\(\(^\(\s\{4}\|
 syntax match  mkdBlockCode  /^\s*\n\(^\(\s\{4}\|\t\).*\n\)\+/
 syntax match  mkdListCode   /^\s*\n\(^\(\s\{8}\|\t{2}\).*\n\)\+/
 syntax match  mkdLineBreak /  \+$/
-syntax region mkdCode       start=/\\\@<!`/     end=/\\\@<!`/
+syntax region mkdCode       start=/\\\@<!`[^`]/     end=/\\\@<![^`]`/
 syntax region mkdCode       start=/\s*``[^`]*/  end=/[^`]*``\s*/
 syntax region mkdBlockquote start=/^\s*>/       end=/$/           contains=mkdLineBreak,mkdLineContinue,@Spell
 syntax region mkdCode       start="<pre[^>]*>"  end="</pre>"

--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -44,7 +44,7 @@ syntax region htmlItalic  start=/\\\@<!\(^\|\A\)\@=\<_\@<!___\@!\S/      end=/\S
 syntax region htmlItalic  start=/\\\@<!\(^\|\A\)\@=\<_\@<!__\@!\S/       end=/\S\\\@<!_\@<!__\@!\($\|\A\)\@=/       contains=htmlBold,@Spell
 
 " [link](URL) | [link][id] | [link][]
-syntax region mkdLink matchgroup=mkdDelimiter start="\!\?\["  end="\]\ze\s*[[(]" contains=@Spell nextgroup=mkdURL,mkdID skipwhite
+syntax region mkdLink matchgroup=mkdDelimiter start="\!\?\["  end="\]\ze\s*[[(]\?" contains=@Spell nextgroup=mkdURL,mkdID skipwhite
 syntax region mkdID   matchgroup=mkdDelimiter start="\["      end="\]" contained
 syntax region mkdURL  matchgroup=mkdDelimiter start="("       end=")"  contained
 


### PR DESCRIPTION
Markdown treats spans as code if they are enclosed within single backticks (e.g. `foo`). The regular expression used to detect these had a corner case which would be triggered if there was only one character in backticks (`a`): Vim would not see the the second backtick, and the syntax region would not be properly closed. The solution was to make one of the regular expression atoms zero-width.
