### PR TITLE
Recognize .mdwn files as Markdown

### DIFF
--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,2 +1,2 @@
 " Markdown
-autocmd BufNewFile,BufRead *.{md,mkd,mkdn,mark*} set filetype=markdown
+autocmd BufNewFile,BufRead *.{md,mdwn,mkd,mkdn,mark*} set filetype=markdown


### PR DESCRIPTION
`.mdwn` is (if you don’t use any hacks) the only supported Markdown extension of the [ikiwiki](http://ikiwiki.info/) wiki system. (No, it’s not configurable.) Since ikiwiki is quite popular for Git and Markdown based wikis, we should support its Markdown file extension.

See also [the ikiwiki mdwn plugin](http://ikiwiki.info/plugins/mdwn/).
