### PR TITLE
Added support for ``` code blocks

### DIFF
--- a/syntax/markdown.vim
+++ b/syntax/markdown.vim
@@ -73,6 +73,7 @@ syntax region mkdCode       start=/\s*``[^`]*/  end=/[^`]*``\s*/
 syntax region mkdBlockquote start=/^\s*>/       end=/$/           contains=mkdLineBreak,mkdLineContinue,@Spell
 syntax region mkdCode       start="<pre[^>]*>"  end="</pre>"
 syntax region mkdCode       start="<code[^>]*>" end="</code>"
+syntax region mkdCode       start="```" end="```"
 
 " HTML headings
 syntax region htmlH1       start="^\s*#"                   end="\($\|#\+\)" contains=@Spell


### PR DESCRIPTION
Added support for GitHub Flavored Markdown code blocks like this:

``` sh
$ tar cvzf foo.tar.bz2 bar/
```
